### PR TITLE
Add default colors to CSS

### DIFF
--- a/fedireads/static/format.css
+++ b/fedireads/static/format.css
@@ -6,6 +6,19 @@
     font-family: sans-serif;
 }
 
+html {
+    background-color:#EFEFEF;
+    color: black;
+}
+
+a {
+    color: #00F;
+}
+
+a:visited {
+    color: #808;
+}
+
 h1, h2, h3, h4 {
     font-weight: normal;
 }


### PR DESCRIPTION
`background-color` and `color` are specified in some places, but there is no default. If the fallback colors in the browsers are not what is expected, it looks weird.

Before: ![screenshot_2020-02-19T22-42-14](https://user-images.githubusercontent.com/3681516/74879495-8f5b0580-5369-11ea-9f44-4713d2730d12.png)

After: ![screenshot_2020-02-19T22-42-04](https://user-images.githubusercontent.com/3681516/74879502-9550e680-5369-11ea-834b-d4c9161abf28.png)



To reproduce, [configure your browser](https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use#w_change-font-color) to use white text on black background as fallback.