### PR TITLE
Show shelf buttons appropriate for current user.

### DIFF
--- a/fedireads/templates/book.html
+++ b/fedireads/templates/book.html
@@ -21,6 +21,8 @@
                 </div>
             </div>
 
+            {% include 'snippets/shelve_button.html' %}
+
         </div>
     </div>
 </div>

--- a/fedireads/templatetags/fr_display.py
+++ b/fedireads/templatetags/fr_display.py
@@ -84,7 +84,7 @@ def shelve_button_identifier(context, book):
     ''' check what shelf a user has a book on, if any '''
     try:
         shelf = models.ShelfBook.objects.get(
-            shelf__user=context['user'],
+            shelf__user=context['request'].user,
             book=book
         )
     except models.ShelfBook.DoesNotExist:
@@ -102,7 +102,7 @@ def shelve_button_text(context, book):
     ''' check what shelf a user has a book on, if any '''
     try:
         shelf = models.ShelfBook.objects.get(
-            shelf__user=context['user'],
+            shelf__user=context['request'].user,
             book=book
         )
     except models.ShelfBook.DoesNotExist:


### PR DESCRIPTION
Use the logged in user rather than user whose books are being viewed to decide which shelf button to display.