### PR TITLE
Don't allow data source to change the primary key of an object.

### DIFF
--- a/fedireads/connectors/abstract_connector.py
+++ b/fedireads/connectors/abstract_connector.py
@@ -70,6 +70,9 @@ def update_from_mappings(obj, data, mappings):
         if not formatter:
             formatter = noop
 
+        if key == 'id':
+            continue
+
         if has_attr(obj, key):
             obj.__setattr__(key, formatter(value))
     return obj


### PR DESCRIPTION
This was a really confusing one to debug!

Openlibrary returns an id, the id gets changed, duplicate error gets raised as django attempts to duplicate the row.

This is the minimal fix for the bug. I think we should work from a whitelist of expected keys as there's lots of exciting things that could get overwritten by unexpected data here (eg: save).

* http://openlibrary.org/works/OL1940021W.json