### PR TITLE
Large imports

### DIFF
--- a/fedireads/goodreads_import.py
+++ b/fedireads/goodreads_import.py
@@ -7,8 +7,8 @@ from fedireads.tasks import app
 from fedireads.models import ImportJob, ImportItem
 from fedireads.status import create_notification
 
-# TODO: remove or notify about this in the UI
-MAX_ENTRIES = 20
+# TODO: remove or increase once we're confident it's not causing problems.
+MAX_ENTRIES = 500
 
 
 def create_job(user, csv_file):

--- a/fedireads/models/import_job.py
+++ b/fedireads/models/import_job.py
@@ -61,7 +61,7 @@ class ImportItem(models.Model):
     def get_book_from_db_isbn(self):
         ''' see if we already know about the book '''
         try:
-            return Edition.objects.get(isbn=self.isbn)
+            return Edition.objects.filter(isbn=self.isbn).first()
         except Edition.DoesNotExist:
             return None
 

--- a/fedireads/models/import_job.py
+++ b/fedireads/models/import_job.py
@@ -89,7 +89,7 @@ class ImportItem(models.Model):
     def shelf(self):
         ''' the goodreads shelf field '''
         if self.data['Exclusive Shelf']:
-            return GOODREADS_SHELVES[self.data['Exclusive Shelf']]
+            return GOODREADS_SHELVES.get(self.data['Exclusive Shelf'])
 
     @property
     def review(self):

--- a/fedireads/templates/import.html
+++ b/fedireads/templates/import.html
@@ -8,6 +8,8 @@
         {{ import_form.as_p }}
         <button type="submit">Import</button>
     </form>
+    <p>
+    Imports are limited in size, and only the first {{ limit }} items will be imported.
 
     <h2>Recent Imports</h2>
     <ul>

--- a/fedireads/views.py
+++ b/fedireads/views.py
@@ -9,6 +9,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from fedireads import activitypub
 from fedireads import forms, models, books_manager
+from fedireads import goodreads_import
 from fedireads.tasks import app
 
 
@@ -162,6 +163,7 @@ def import_page(request):
         'import_form': forms.ImportForm(),
         'jobs': models.ImportJob.
                 objects.filter(user=request.user).order_by('-created_date'),
+        'limit': goodreads_import.MAX_ENTRIES,
     })
 
 


### PR DESCRIPTION
Increase import limit and fix a few bugs that appeared on the larger dataset.

It took 25 minutes to import 287 items, but the fedireads remained responsive and it could deal with other tasks during the import.

287 entries leads to 2075 editions.