### PR TITLE
Use fetch_remote_user and key refreshes.

### DIFF
--- a/fedireads/incoming.py
+++ b/fedireads/incoming.py
@@ -45,6 +45,10 @@ def shared_inbox(request):
         return HttpResponseBadRequest()
 
     if not has_valid_signature(request, activity):
+        if activity['type'] == 'Delete':
+            # Pretend that unauth'd deletes succeed. Auth may be failing because
+            # the resource or owner of the resource might have been deleted.
+            return HttpResponse()
         return HttpResponse(status=401)
 
     handlers = {

--- a/fedireads/remote_user.py
+++ b/fedireads/remote_user.py
@@ -17,17 +17,7 @@ def get_or_create_remote_user(actor):
     except models.User.DoesNotExist:
         pass
 
-    # load the user's info from the actor url
-    response = requests.get(
-        actor,
-        headers={'Accept': 'application/activity+json'}
-    )
-    if not response.ok:
-        response.raise_for_status()
-    data = response.json()
-
-    # make sure our actor is who they say they are
-    assert actor == data['id']
+    data = fetch_user_data(actor)
 
     actor_parts = urlparse(actor)
     with transaction.atomic():
@@ -42,6 +32,21 @@ def get_or_create_remote_user(actor):
     if user.fedireads_user:
         get_remote_reviews(user)
     return user
+
+def fetch_user_data(actor):
+    # load the user's info from the actor url
+    response = requests.get(
+        actor,
+        headers={'Accept': 'application/activity+json'}
+    )
+    if not response.ok:
+        response.raise_for_status()
+    data = response.json()
+
+    # make sure our actor is who they say they are
+    if actor != data['id']:
+        raise ValueError("Remote actor id must match url.")
+    return data
 
 
 def create_remote_user(data):
@@ -72,6 +77,24 @@ def create_remote_user(data):
             'manuallyApprovesFollowers', False),
     )
 
+def refresh_remote_user(user):
+    data = fetch_user_data(user.remote_id)
+
+    shared_inbox = data.get('endpoints').get('sharedInbox') if \
+        data.get('endpoints') else None
+
+    # TODO - I think dataclasses change will mean less repetition here later.
+    user.name = data.get('name')
+    user.summary = data.get('summary')
+    user.inbox = data['inbox'] #fail if there's no inbox
+    user.outbox = data['outbox'] # fail if there's no outbox
+    user.shared_inbox = shared_inbox
+    user.public_key = data.get('publicKey').get('publicKeyPem')
+    user.local = False
+    user.fedireads_user = data.get('fedireadsUser', False)
+    user.manually_approves_followers = data.get(
+        'manuallyApprovesFollowers', False)
+    user.save()
 
 def get_avatar(data):
     ''' find the icon attachment and load the image from the remote sever '''

--- a/fedireads/remote_user.py
+++ b/fedireads/remote_user.py
@@ -36,7 +36,8 @@ def get_or_create_remote_user(actor):
         user.save()
 
     avatar = get_avatar(data)
-    user.avatar.save(*avatar)
+    if avatar:
+        user.avatar.save(*avatar)
 
     if user.fedireads_user:
         get_remote_reviews(user)

--- a/fedireads/tests/test_signing.py
+++ b/fedireads/tests/test_signing.py
@@ -99,6 +99,58 @@ class Signature(TestCase):
         self.assertEqual(response.status_code, 200)
 
     @responses.activate
+    def test_key_needs_refresh(self):
+        datafile = pathlib.Path(__file__).parent.joinpath('data/ap_user.json')
+        data = json.loads(datafile.read_bytes())
+        data['id'] = self.fake_remote.remote_id
+        data['publicKey']['publicKeyPem'] = self.fake_remote.public_key
+        del data['icon'] # Avoid having to return an avatar.
+        responses.add(
+            responses.GET,
+            self.fake_remote.remote_id,
+            json=data,
+            status=200)
+        responses.add(
+            responses.GET,
+            'https://localhost/.well-known/nodeinfo',
+            status=404)
+        responses.add(
+            responses.GET,
+            'https://example.com/user/mouse/outbox?page=true',
+            json={'orderedItems': []},
+            status=200
+        )
+
+        # Second and subsequent fetches get a different key:
+        new_private_key, new_public_key = create_key_pair()
+        new_sender = Sender(
+            self.fake_remote.remote_id, new_private_key, new_public_key)
+        data['publicKey']['publicKeyPem'] = new_public_key
+        responses.add(
+            responses.GET,
+            self.fake_remote.remote_id,
+            json=data,
+            status=200)
+
+
+        # Key correct:
+        response = self.send_test_request(sender=self.fake_remote)
+        self.assertEqual(response.status_code, 200)
+
+        # Old key is cached, so still works:
+        response = self.send_test_request(sender=self.fake_remote)
+        self.assertEqual(response.status_code, 200)
+
+        # Try with new key:
+        response = self.send_test_request(sender=new_sender)
+        self.assertEqual(response.status_code, 200)
+
+        # Now the old key will fail:
+        response = self.send_test_request(sender=self.fake_remote)
+        self.assertEqual(response.status_code, 401)
+
+
+    @responses.activate
     def test_nonexistent_signer(self):
         responses.add(
             responses.GET,


### PR DESCRIPTION
* Use fetch_remote_user to get public_key for authentication.
* Refresh user data and retry on authentication failure.

Btw, would ```fetch_remote_user``` be better as a class method on the User class? (```User.fetch_remote``` and ```User.refresh_remote``` perhaps?)