### PR TITLE
Add Author.display_name to decide which name to display

### DIFF
--- a/fedireads/models/book.py
+++ b/fedireads/models/book.py
@@ -184,3 +184,14 @@ class Author(FedireadsModel):
     @property
     def activitypub_serialize(self):
         return activitypub.get_author(self)
+
+    @property
+    def display_name(self):
+        ''' Helper to return a displayable name'''
+        if self.name:
+            return name
+        # don't want to return a spurious space if all of these are None
+        elif self.first_name and self.last_name:
+            return self.first_name + ' ' + self.last_name
+        else:
+            return self.last_name or self.first_name

--- a/fedireads/templates/author.html
+++ b/fedireads/templates/author.html
@@ -2,7 +2,7 @@
 {% load fr_display %}
 {% block content %}
 <div class="content-container">
-    <h2>{{ author.name }}</h2>
+    <h2>{{ author.display_name }}</h2>
 
     {% if author.bio %}
     <p>
@@ -12,7 +12,7 @@
 </div>
 
 <div class="content-container">
-    <h2>Books by {{ author.name }}</h2>
+    <h2>Books by {{ author.display_name }}</h2>
     <div class="book-grid row shrink wrap">
         {% for book in books %}
         <div class="book-preview">

--- a/fedireads/templates/snippets/authors.html
+++ b/fedireads/templates/snippets/authors.html
@@ -1,1 +1,1 @@
-<a href="/author/{{ book.authors.first.id }}" class="author">{{ book.authors.first.name }}</a>
+<a href="/author/{{ book.authors.first.id }}" class="author">{{ book.authors.first.display_name }}</a>

--- a/fedireads/templates/snippets/shelf.html
+++ b/fedireads/templates/snippets/shelf.html
@@ -42,7 +42,7 @@
         <a href="/book/{{ book.id }}">{{ book.title }}</a>
     </td>
     <td>
-        {{ book.authors.first.name }}
+        {{ book.authors.first.display_name }}
     </td>
     <td>
         {% if book.first_published_date %}{{ book.first_published_date }}{% endif %}


### PR DESCRIPTION
When poking around the app locally, I noticed that author names weren't showing up because the templates look for `Author#name` but the authors were getting stored in my db with `first_name` and `last_name`.

It seemed to me (knowing very little about about either Django or the data model :) ) that the easiest solution is to display `first_name last_name` if `name` doesn't exist. So I implemented that as a property on the author model (not sure if this is the preferred approach?).

If there is some other strategy that would make more sense let me know!